### PR TITLE
Remove source map generation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpfy",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpfy",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpfy",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A utility to convert images to WebP format",
   "main": "dist/webpfy.js",
   "types": "dist/webpfy.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,16 @@
 {
     "compilerOptions": {
-      "target": "ES2021", // Target ES version supported by Node.js 18
-      "module": "ESNext", // ES modules
-      "outDir": "./dist",                // Specify the output directory for compiled JavaScript files
-      "rootDir": "./src",                // Specify the root directory of your TypeScript source files
-      "strict": true,                    // Enable strict type checking
-      "esModuleInterop": true,           // Allow default imports from modules with no default export
-      "skipLibCheck": true,              // Skip type checking of declaration files
-      "forceConsistentCasingInFileNames": true,  // Ensure consistent file name casing
-      "declaration": true,               // Generate TypeScript declaration files (.d.ts)
-      "declarationDir": "./dist",        // Specify the output directory for declaration files
-      "sourceMap": true                  // Generate source maps for easier debugging
+        "target": "ES2021", // Target ES version supported by Node.js 18
+        "module": "ESNext", // ES modules
+        "outDir": "./dist", // Specify the output directory for compiled JavaScript files
+        "rootDir": "./src", // Specify the root directory of your TypeScript source files
+        "strict": true, // Enable strict type checking
+        "esModuleInterop": true, // Allow default imports from modules with no default export
+        "skipLibCheck": true, // Skip type checking of declaration files
+        "forceConsistentCasingInFileNames": true, // Ensure consistent file name casing
+        "declaration": true, // Generate TypeScript declaration files (.d.ts)
+        "declarationDir": "./dist" // Specify the output directory for declaration files
     },
-    "include": ["src/**/*.ts"],          // Specify the files to include in compilation
-    "exclude": ["node_modules"]          // Specify the files and directories to exclude from compilation
-  }
-  
+    "include": ["src/**/*.ts"], // Specify the files to include in compilation
+    "exclude": ["node_modules"] // Specify the files and directories to exclude from compilation
+}


### PR DESCRIPTION
The minified js file is almost as similar as the actual typescript file. Source map generation for this felt unnecessary